### PR TITLE
use --port as is

### DIFF
--- a/cmd/wingman/server.go
+++ b/cmd/wingman/server.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 
 	"github.com/adrianliechti/wingman-agent/server"
@@ -10,7 +11,7 @@ import (
 
 func runServer(ctx context.Context) {
 	fs := flag.NewFlagSet("server", flag.ExitOnError)
-	port := fs.Int("port", 9000, "port to listen on")
+	port := fs.Int("port", 0, fmt.Sprintf("port to listen on (default: %d, falls back to random if taken)", server.DefaultPort))
 	noBrowser := fs.Bool("no-browser", false, "do not open browser on startup")
 	fs.Parse(os.Args[2:])
 
@@ -20,7 +21,6 @@ func runServer(ctx context.Context) {
 	}
 
 	srv, err := server.New(ctx, wd, &server.ServerOptions{
-		Port:      *port,
 		NoBrowser: *noBrowser,
 	})
 	if err != nil {
@@ -28,7 +28,7 @@ func runServer(ctx context.Context) {
 	}
 	defer srv.Close()
 
-	if err := srv.Run(ctx); err != nil {
+	if err := srv.Run(ctx, *port); err != nil {
 		fatal(err)
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -38,13 +38,14 @@ var staticFiles embed.FS
 
 var StaticFS, _ = fs.Sub(staticFiles, "static")
 
+// DefaultPort is the preferred port used when no explicit port is requested.
+const DefaultPort = 9000
+
 type ServerOptions struct {
-	Port      int
 	NoBrowser bool
 }
 
 type Server struct {
-	port      int
 	noBrowser bool
 
 	workspace *code.Workspace
@@ -91,7 +92,6 @@ func New(ctx context.Context, workDir string, opts *ServerOptions) (*Server, err
 	}
 
 	s := &Server{
-		port:           opts.Port,
 		noBrowser:      opts.NoBrowser,
 		workspace:      ws,
 		config:         cfg,
@@ -198,20 +198,18 @@ func (s *Server) handleWebSocketURL(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, map[string]string{"url": fmt.Sprintf("%s://%s/ws", proto, r.Host)})
 }
 
-func (s *Server) Run(ctx context.Context) error {
-
+func (s *Server) Run(ctx context.Context, port int) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	s.ctx = ctx
 
-	port, err := system.FreePort(s.port)
+	resolvedPort, err := resolvePort(port)
 	if err != nil {
 		return err
 	}
-	s.port = port
 
 	srv := &http.Server{
-		Addr:    fmt.Sprintf("localhost:%d", s.port),
+		Addr:    fmt.Sprintf("localhost:%d", resolvedPort),
 		Handler: s,
 	}
 
@@ -223,7 +221,7 @@ func (s *Server) Run(ctx context.Context) error {
 		srv.Close()
 	}()
 
-	url := fmt.Sprintf("http://localhost:%d", s.port)
+	url := fmt.Sprintf("http://localhost:%d", resolvedPort)
 	fmt.Fprintf(os.Stderr, "Wingman running at %s\n", url)
 
 	if !s.noBrowser {
@@ -789,6 +787,13 @@ func convertMessages(messages []agent.Message) []ConversationMessage {
 func writeJSON(w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(v)
+}
+
+func resolvePort(port int) (int, error) {
+	if port != 0 {
+		return port, nil
+	}
+	return system.FreePort(DefaultPort)
 }
 
 func (s *Server) constructBackend(name string) (code.Agent, error) {


### PR DESCRIPTION
An explicit --port is now used directly (failing at startup if unavailable), while an unset port still auto-selects 9000 with random fallback.